### PR TITLE
SystemUI: Add FingerprintInteractiveToAuthProvider implementation

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/biometrics/FingerprintInteractiveToAuthProviderImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/FingerprintInteractiveToAuthProviderImpl.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 ArrowOS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui.biometrics;
+
+import android.content.Context;
+import android.provider.Settings;
+
+import javax.inject.Inject;
+
+public class FingerprintInteractiveToAuthProviderImpl implements
+        FingerprintInteractiveToAuthProvider {
+
+    private final Context mContext;
+    private final int mDefaultValue;
+
+    @Inject
+    public FingerprintInteractiveToAuthProviderImpl(Context context) {
+        mContext = context;
+        mDefaultValue = context.getResources().getBoolean(
+                com.android.internal.R.bool.config_performantAuthDefault) ? 1 : 0;
+    }
+
+    public boolean isEnabled(int userId) {
+        int value = Settings.Secure.getIntForUser(mContext.getContentResolver(),
+                Settings.Secure.SFPS_PERFORMANT_AUTH_ENABLED, -1, userId);
+        if (value == -1) {
+            value = mDefaultValue;
+            Settings.Secure.putIntForUser(mContext.getContentResolver(),
+                    Settings.Secure.SFPS_PERFORMANT_AUTH_ENABLED, value, userId);
+        }
+        return value == 0;
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/biometrics/dagger/BiometricsModule.kt
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/dagger/BiometricsModule.kt
@@ -16,6 +16,7 @@
 
 package com.android.systemui.biometrics.dagger
 
+import android.content.Context
 import com.android.settingslib.udfps.UdfpsUtils
 import com.android.systemui.biometrics.data.repository.FingerprintPropertyRepository
 import com.android.systemui.biometrics.data.repository.FingerprintPropertyRepositoryImpl
@@ -33,6 +34,8 @@ import com.android.systemui.biometrics.domain.interactor.SideFpsOverlayInteracto
 import com.android.systemui.biometrics.domain.interactor.SideFpsOverlayInteractorImpl
 import com.android.systemui.biometrics.domain.interactor.PromptSelectorInteractor
 import com.android.systemui.biometrics.domain.interactor.PromptSelectorInteractorImpl
+import com.android.systemui.biometrics.FingerprintInteractiveToAuthProvider
+import com.android.systemui.biometrics.FingerprintInteractiveToAuthProviderImpl
 import com.android.systemui.dagger.SysUISingleton
 import com.android.systemui.util.concurrency.ThreadFactory
 import dagger.Binds
@@ -87,6 +90,10 @@ interface BiometricsModule {
         @BiometricsBackground
         fun providesPluginExecutor(threadFactory: ThreadFactory): Executor =
             threadFactory.buildExecutorOnNewThread("biometrics")
+
+        @Provides
+        fun providesFingerprintInteractiveToAuth(ctx: Context): FingerprintInteractiveToAuthProvider =
+            FingerprintInteractiveToAuthProviderImpl(ctx);
 
         @Provides
         fun providesUdfpsUtils(): UdfpsUtils = UdfpsUtils()


### PR DESCRIPTION
This is required for the "touch to unlock anytime" setting on devices with side mounted fingerprint sensor.

Ref: 66a048d646fd816e7757e300c62fa5cebf04761d

Change-Id: If3308860a428d9966f2b0a0024764df95f8f9a8b